### PR TITLE
fix: 빌드 에러 수정

### DIFF
--- a/apps/paws-time/app/board/write/page.tsx
+++ b/apps/paws-time/app/board/write/page.tsx
@@ -1,10 +1,11 @@
 import BoardWriteBody from "./body";
+import { Suspense } from "react";
 
 const BoardWritePage = () => {
   return (
-    <div>
+    <Suspense fallback={<div>로딩 중...</div>}>
       <BoardWriteBody />
-    </div>
+    </Suspense>
   );
 };
 


### PR DESCRIPTION
useSearchParams() 사용 시 CSR 처리를 위해 <Suspense>로 감쌌습니다.
Next.js 13+ 이상에서는 해당 훅 사용 시 suspense로 감싸야 빌드 에러가 발생하지 않습니다.